### PR TITLE
Feature: set report output directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-tslint-jenkins-reporter",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "gulp-tslint checkstyle reporter, to be used by Jenkins (Hudson). Writes output to an xml file.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "lodash": "^4.11.2",
+    "mkdirp": "^0.5.1",
     "plexer": "^1.0.1",
     "readable-stream": "^2.1.2",
     "upath": "^0.1.7",

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -46,6 +46,8 @@ function report(options) {
         
         const content = formatter.formatStream(filesBuffer, settings);
 
+        outputStream.end();
+
         if (settings.outputDir) {
             mkdirp(settings.outputDir, function() {
                 outputReport(upath.join(settings.outputDir, settings.filename), content, done);
@@ -63,8 +65,7 @@ function outputReport(filename, content, done) {
         if (err) {
             console.error(err);
         }
-        
-        outputStream.end();
+
         done();
     });
 }

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -89,7 +89,7 @@ function getSettings(options) {
     }
 
     if (settings.outputDir) {
-        settings.outputDir = upath.join(__dirname, settings.outputDir);
+        settings.outputDir = upath.normalize(settings.outputDir);
     }
     
     return settings;

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -64,7 +64,7 @@ function outputReport(filename, content, done) {
             console.error(err);
         }
         
-        done();
+        return done();
     });
 }
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -48,23 +48,23 @@ function report(options) {
 
         if (settings.outputDir) {
             mkdirp(settings.outputDir, function() {
-                outputReport(upath.join(settings.outputDir, settings.filename), content, done);
+                outputReport(upath.join(settings.outputDir, settings.filename), content);
             });
         } else {
-            outputReport(settings.filename, content, done);
+            outputReport(settings.filename, content);
         }
+
+        done();
     };
     
     return stream;
 }
 
-function outputReport(filename, content, done) {
+function outputReport(filename, content) {
     fs.writeFile(filename, content, function(err) {
         if (err) {
             console.error(err);
         }
-        
-        return done();
     });
 }
 

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -7,13 +7,15 @@ const path = require('path');
 const plexer = require('plexer');
 const Stream = require('readable-stream');
 const upath = require('upath');
+const mkdirp = require('mkdirp');
 
 const Formatter = require('./formatter');
 
 module.exports = {
     getReportedFilePath: getReportedFilePath,
     getSettings: getSettings,
-    report: report
+    report: report,
+    outputReport: outputReport
 };
 
 function report(options) {
@@ -43,16 +45,27 @@ function report(options) {
         }
         
         const content = formatter.formatStream(filesBuffer, settings);
-        fs.writeFile(settings.filename, content, function(err) {
-            if (err) {
-                console.error(err);
-            }
-            
-            done();
-        });
+
+        if (settings.outputDir) {
+            mkdirp(settings.outputDir, function() {
+                outputReport(upath.join(settings.outputDir, settings.filename), content, done);
+            });
+        } else {
+            outputReport(settings.filename, content, done);
+        }
     };
     
     return stream;
+}
+
+function outputReport(filename, content, done) {
+    fs.writeFile(filename, content, function(err) {
+        if (err) {
+            console.error(err);
+        }
+        
+        done();
+    });
 }
 
 function getSettings(options) {
@@ -61,6 +74,7 @@ function getSettings(options) {
     _.defaults(settings, {
         sort: false,
         filename: 'checkstyle.xml',
+        outputDir: '',
         severity: 'error',
         pathBase: '',
         pathPrefix: ''
@@ -72,6 +86,10 @@ function getSettings(options) {
     
     if (settings.pathPrefix) {
         settings.pathPrefix = upath.normalize(settings.pathPrefix);
+    }
+
+    if (settings.outputDir) {
+        settings.outputDir = upath.join(__dirname, settings.outputDir);
     }
     
     return settings;

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -48,23 +48,24 @@ function report(options) {
 
         if (settings.outputDir) {
             mkdirp(settings.outputDir, function() {
-                outputReport(upath.join(settings.outputDir, settings.filename), content);
+                outputReport(upath.join(settings.outputDir, settings.filename), content, done);
             });
         } else {
-            outputReport(settings.filename, content);
+            outputReport(settings.filename, content, done);
         }
-
-        done();
     };
     
     return stream;
 }
 
-function outputReport(filename, content) {
+function outputReport(filename, content, done) {
     fs.writeFile(filename, content, function(err) {
         if (err) {
             console.error(err);
         }
+        
+        outputStream.end();
+        done();
     });
 }
 


### PR DESCRIPTION
Adds an outputDir option that allows you to set where you want the checkstyle report file to be output