### PR TITLE
Add carat to gulp-tslint@8 peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node": ">=4.0.0"
   },
   "peerDependencies": {
-    "gulp-tslint": "^5.0.0 || ^6.1.3 || ^7.0.1 || 8.0.0"
+    "gulp-tslint": "^5.0.0 || ^6.1.3 || ^7.0.1 || ^8.0.0"
   },
   "dependencies": {
     "lodash": "^4.17.2",


### PR DESCRIPTION
Hi! I'd love to use this, but am getting a peerDependency error. Since gulp-tslint is now up to `8.1.2`, a carat range would resolve this.

Thanks!